### PR TITLE
Block database initialization

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,12 @@
 
 ## Requirements
 
+0. Library
+
+```bash
+sudo apt install libmariadb-dev
+```
+
 1. Download (bitcoin core)[https://bitcoin.org/en/download] and Block data
 
 ```bash
@@ -45,6 +51,17 @@ bitcoind -reindex -rescan
 
 - [Install on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
 
+```bash
+sudo apt install ca-certificates curl gnupg lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+# uno to focal
+sudo vi /etc/apt/sources.list.d/docker.list
+sudo apt update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+```
+
 - (Recommended) Running docker on a non-root user
 
 - [Guide: Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/)
@@ -54,6 +71,8 @@ sudo usermod -aG docker $USER
 ```
 
 - [MariaDB Docker Hub Reference](https://hub.docker.com/_/mariadb)
+
+  - [System Variable](https://mariadb.com/kb/en/server-system-variables/)
 
 ```bash
 docker pull mariadb

--- a/SCHEMA.sql
+++ b/SCHEMA.sql
@@ -1,0 +1,8 @@
+CREATE TABLE blk (
+  id INT NOT NULL,
+  blkhash CHAR(64) NOT NULL,
+  miningtime TIMESTAMP NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (blkhash)
+);
+CREATE INDEX idx_miningtime ON blk (miningtime);

--- a/premain_database_initialization.py
+++ b/premain_database_initialization.py
@@ -33,7 +33,7 @@ def main():
     if FLAGS.reset:
         cur.execute('''DROP TABLE IF EXISTS blk;''')
         if DEBUG:
-            print(f'[{int(time.time()-STIME)}] DROP all tables of {secret.db_database}')
+            print(f'[{int(time.time()-STIME)}] DROP all tables of {secret.db_databasename}')
 
     cur.execute('''CREATE TABLE blk (
                      id INT NOT NULL,

--- a/premain_database_initialization.py
+++ b/premain_database_initialization.py
@@ -38,7 +38,7 @@ def main():
     cur.execute('''CREATE TABLE blk (
                      id INT NOT NULL,
                      blkhash CHAR(64) NOT NULL,
-                     miningtime TIMESTAMP NOT NULL,
+                     miningtime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                      PRIMARY KEY (id),
                      UNIQUE (blkhash)
                    );''')
@@ -47,8 +47,21 @@ def main():
 
     cur.execute('''SHOW TABLES;''')
     res = cur.fetchall()
+    tables = []
     if DEBUG:
-        print(f'[{int(time.time()-STIME)}] CREATE TABLES: {res}')
+        print(f'[{int(time.time()-STIME)}] CREATE TABLES:')
+    for row in res:
+        tables.append(row[0])
+        if DEBUG:
+            print(f'[{int(time.time()-STIME)}] > {table}')
+    if DEBUG:
+        for table in tables:
+            print(f'[{int(time.time()-STIME)}] > DESCRIBE {table}')
+            cur.execute(f'''DESCRIBE {table};''')
+            res = cur.fetchall()
+            for row in res:
+                print(f'[{int(time.time()-STIME)}] >> {row}')
+
 
     conn.commit()
     conn.close()

--- a/premain_database_initialization.py
+++ b/premain_database_initialization.py
@@ -1,0 +1,22 @@
+FLAGS = _ = None
+DEBUG = False
+
+
+def main():
+    if DEBUG:
+        print(f'Parsed arguments {FLAGS}')
+        print(f'Unparsed arguments {_}')
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true',
+                        help='The present debug message')
+
+    FLAGS, _ = parser.parse_known_args()
+    DEBUG = FLAGS.debug
+
+    main()
+

--- a/premain_database_initialization.py
+++ b/premain_database_initialization.py
@@ -16,11 +16,17 @@ def main():
         print(f'Parsed arguments {FLAGS}')
         print(f'Unparsed arguments {_}')
 
-    conn, cur = utils.connectdb(user=secret.db_username,
-                                password=secret.db_password,
-                                host=secret.db_host,
-                                port=secret.db_port,
-                                database=secret.db_databasename)
+    try:
+        conn = mariadb.connect(user=secret.db_username,
+                               password=secret.db_password,
+                               host=secret.db_host,
+                               port=secret.db_port,
+                               database=secret.db_databasename)
+        cur = conn.cursor()
+    except mariadb.Error as e:
+        print(f'Error connecting to MariaDB: {e}')
+        sys.exit(0)
+
     if DEBUG:
         print(f'[{int(time.time()-STIME)}] Connect to database')
 

--- a/premain_database_initialization.py
+++ b/premain_database_initialization.py
@@ -1,5 +1,14 @@
+import os
+import time
+
+import mariadb
+
+import secret
+
+
 FLAGS = _ = None
 DEBUG = False
+STIME = time.time()
 
 
 def main():
@@ -7,13 +16,50 @@ def main():
         print(f'Parsed arguments {FLAGS}')
         print(f'Unparsed arguments {_}')
 
+    conn, cur = utils.connectdb(user=secret.db_username,
+                                password=secret.db_password,
+                                host=secret.db_host,
+                                port=secret.db_port,
+                                database=secret.db_databasename)
+    if DEBUG:
+        print(f'[{int(time.time()-STIME)}] Connect to database')
+
+    if FLAGS.reset:
+        cur.execute('''DROP TABLE IF EXISTS blk;''')
+        if DEBUG:
+            print(f'[{int(time.time()-STIME)}] DROP all tables of {secret.db_database}')
+
+    cur.execute('''CREATE TABLE blk (
+                     id INT NOT NULL,
+                     blkhash CHAR(64) NOT NULL,
+                     miningtime TIMESTAMP NOT NULL,
+                     PRIMARY KEY (id),
+                     UNIQUE (blkhash)
+                   );''')
+    cur.execute('''CREATE INDEX idx_miningtime ON blk (miningtime);''')
+    conn.commit()
+
+    cur.execute('''SHOW TABLES;''')
+    res = cur.fetchall()
+    if DEBUG:
+        print(f'[{int(time.time()-STIME)}] CREATE TABLES: {res}')
+
+    conn.commit()
+    conn.close()
+
 
 if __name__ == '__main__':
     import argparse
 
+    root_path = os.path.abspath(__file__)
+    root_dir = os.path.dirname(root_path)
+    os.chdir(root_dir)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', action='store_true',
                         help='The present debug message')
+    parser.add_argument('--reset', action='store_true',
+                        help='Clear exists tables before creation')
 
     FLAGS, _ = parser.parse_known_args()
     DEBUG = FLAGS.debug

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # JSON RPC from bitcoind
 python-bitcoinrpc
-
+# MariaDB connector
+mariadb
 # ZeroMQ
 pyzmq


### PR DESCRIPTION
Database creation and initialization for Issue #4
We can database Initialization using with the following command
The `--reset` flag erases and initializes the database that has already been created.

```bash
python3 premain_database_initialization.py --debug --reset
```

I hope @Yujin-nKim will merge after code review.
We should not remove the branch, but leave it for future development (the issue is not resolved yet).